### PR TITLE
fixate dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ rvm:
 - 1.9.3
 - 2.3.0
 - jruby-19mode
-- rbx-2
+- rbx-3
 deploy:
   provider: rubygems
   on:
     tags: true
   api_key:
     secure: XFUKxH18R6lT5In7phyVsL3a5mcESrssD2dlNrQvC2TXeBGif+0sSSt7ZfRuFve5XB0Wa8ruClFxRr0uMXRqUZUKc1/VbLM2DnLLkruK8pwdu2oQI3JMdcDtMmVsVxvJViAAy3ibuKuCTF2NbU+Yg/VrwMNU+aN63zsDR44t1IU=
+dist: trusty

--- a/talos.gemspec
+++ b/talos.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.version       = '0.1.4'
+  s.version       = '0.1.5'
   s.name          = 'talos'
   s.authors       = ['Alexey Lapitsky', 'Johan Haals']
   s.email         = 'alexey@spotify.com'
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'rack', '< 1.6'
-  s.add_dependency 'sinatra'
-  s.add_dependency 'hiera'
-  s.add_dependency 'archive-tar-minitar'
+  s.add_dependency 'sinatra', '~> 1.4.7'
+  s.add_dependency 'hiera', '~> 3.2.0'
+  s.add_dependency 'archive-tar-minitar', '~> 0.5.2'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'sinatra-contrib'
   s.add_development_dependency 'rspec', '>= 2.9'


### PR DESCRIPTION
Latest sinatra requires `rack ~> 2.0`, breaking install of this gem. This PR fixates sinatra to version `1.4.7`. It also bumps talos version to `0.1.5`.