### PR TITLE
Add optional talos setting `ssl`; default `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ scopes:
       environment: testing
 
 unsafe_scopes: true
+ssl: true
 ```
 
 When receiving a request, Talos iterates over `scopes` list and matches
@@ -70,6 +71,9 @@ scope on collision.
 
 If `unsafe_scopes` option is enabled, Talos will also add all the parameters
 passed by the client to the Hiera scope.
+
+The `ssl` option defaults to enabled. When disabled, the `fqdn` query parameter
+is used to determine scopes rather than the client certificate.
 
 Hiera
 -----

--- a/talos.gemspec
+++ b/talos.gemspec
@@ -1,12 +1,12 @@
 Gem::Specification.new do |s|
-  s.version       = '0.1.5'
+  s.version       = '0.1.6'
   s.name          = 'talos'
   s.authors       = ['Alexey Lapitsky', 'Johan Haals']
   s.email         = 'alexey@spotify.com'
   s.summary       = %q{Hiera secrets distribution over HTTP}
   s.description   = %q{Distribute compressed hiera yaml files to authenticated puppet clients over HTTP}
   s.homepage      = 'https://github.com/spotify/talos'
-  s.license       = 'Apache 2.0'
+  s.license       = 'Apache-2.0'
 
   s.files         = `git ls-files`.split($\)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This makes talos' use of client certificates configurable. The use case
for this is for deployments where talos can bind to localhost alongside
a trusted peer. The two services can then share the local interface.