### PR TITLE
Bump rack. Try to get fqdn from alternative env variable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 1.9.3
 - 2.3.0
 - jruby-19mode
-- rbx-3
+
 deploy:
   provider: rubygems
   on:

--- a/lib/talos.rb
+++ b/lib/talos.rb
@@ -100,7 +100,8 @@ class Talos < Sinatra::Base
   end
 
   get '/' do
-    fqdn = (settings.development? || !settings.talos['ssl']) ? params[:fqdn] : request.env['HTTP_SSL_CLIENT_S_DN_CN']
+    fqdn_env = request.env['HTTP_SSL_CLIENT_S_DN_CN'] ? request.env['HTTP_SSL_CLIENT_S_DN_CN'] : request.env['SSL_CLIENT_S_DN_CN'] 
+    fqdn = (settings.development? || !settings.talos['ssl']) ? params[:fqdn] : fqdn_env
     scope = get_scope(fqdn)
     files_to_pack = files_in_scope(scope)
     archive = compress_files(files_to_pack)

--- a/talos.gemspec
+++ b/talos.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.version       = '0.1.6'
+  s.version       = '0.1.7'
   s.name          = 'talos'
   s.authors       = ['Alexey Lapitsky', 'Johan Haals']
   s.email         = 'alexey@spotify.com'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_dependency 'rack', '< 1.6'
+  s.add_dependency 'rack', '~> 1.6'
   s.add_dependency 'sinatra', '~> 1.4.7'
   s.add_dependency 'hiera', '~> 3.2.0'
   s.add_dependency 'archive-tar-minitar', '~> 0.5.2'

--- a/talos.gemspec
+++ b/talos.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'rack', '1.6.4'
   s.add_dependency 'sinatra', '~> 1.4.7'
   s.add_dependency 'hiera', '~> 3.2.0'
   s.add_dependency 'archive-tar-minitar', '~> 0.5.2'


### PR DESCRIPTION
Bumping rack should fix this error when installing on fresh Bionic
machine:
```
Message from application: Unable to activate talos-0.1.5, because rack-1.6.4 conflicts with rack (< 1.6) (Gem::ConflictError)
```

Newer version of rack/apache does not prefix `SSL_CLIENT_S_DN_CN` with
HTTP. This tries to read it from the old env before picking the
unprefixed environment variable.