### PR TITLE
Update Rack to 2.2.3.1

### DIFF
--- a/talos.gemspec
+++ b/talos.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_dependency 'rack', '2.2.3'
+  s.add_dependency 'rack', '2.2.3.1'
   s.add_dependency 'sinatra', '~> 2.2.0'
   s.add_dependency 'hiera', '~> 3.6.0'
   s.add_dependency 'minitar', '~> 0.9'

--- a/talos.gemspec
+++ b/talos.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
-  s.version       = '1.0.1'
+  s.version       = '1.0.2'
   s.name          = 'talos'
-  s.authors       = ['Alexey Lapitsky', 'Johan Haals']
-  s.email         = 'alexey@spotify.com'
+  s.authors       = ['Alexey Lapitsky', 'Johan Haals', 'Wasabi']
+  s.email         = 'wasabi@spotify.com'
   s.summary       = %q{Hiera secrets distribution over HTTP}
   s.description   = %q{Distribute compressed hiera yaml files to authenticated puppet clients over HTTP}
   s.homepage      = 'https://github.com/spotify/talos'


### PR DESCRIPTION
Rack 2.2.3.0 is vulnerable to CVE-2022-30123¹ and CVE-2022-30122².

1: https://github.com/advisories/GHSA-wq4h-7r42-5hrr
2: https://github.com/advisories/GHSA-hxqx-xwvh-44m2