### PR TITLE
Drop testing on Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7']
+        ruby-version: ['2.6', '2.7']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The build tools can no longer be installed on Ruby 2.5, so drop testing on that versions. Users still on 2.5 should move to a newer Ruby version.